### PR TITLE
Update cleaner.dart

### DIFF
--- a/lib/src/cleaner.dart
+++ b/lib/src/cleaner.dart
@@ -1,13 +1,31 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
+import 'package:yaml/yaml.dart';
 
-/// Scans the project for unused localization keys and removes them from `.arb` files.
+/// Read l10n.yaml and checking (now Flutter Depracte Flutter_gen and l10n became required at all )
 void runLocalizationCleaner({bool keepUnused = false}) {
-  final Directory localizationDir = Directory('lib/l10n');
-  final Set<String> excludedFiles = {'lib/l10n/app_localizations.dart'};
+  final File yamlFile = File('l10n.yaml'); // Path to your l10n.yaml file
+  if (!yamlFile.existsSync()) {
+    print('Error: l10n.yaml file not found!');
+    return;
+  }
 
-  // Get all .arb files dynamically
+  // Read & parse YAML
+  final String yamlContent = yamlFile.readAsStringSync();
+  final Map yamlData = loadYaml(yamlContent);
+
+  // Extract values dynamically
+  final String arbDir = yamlData['arb-dir'] as String;
+  final String outputDir = yamlData['output-dir'] as String;
+  final String outputFile = yamlData['output-localization-file'] as String;
+  final String locClassName = yamlData['output-class'] as String;
+
+  // Construct values
+  final Directory localizationDir = Directory(arbDir);
+  final Set<String> excludedFiles = {'$outputDir/$outputFile'};
+
+ //read arb file
   final List<File> localizationFiles =
       localizationDir
           .listSync()
@@ -35,27 +53,32 @@ void runLocalizationCleaner({bool keepUnused = false}) {
 
   final Set<String> usedKeys = <String>{};
   final Directory libDir = Directory('lib');
+//improve Reg Exp 
+  final String keysPattern = allKeys.map(RegExp.escape).join('|');
+  final RegExp regex = RegExp(
+    r'(?:' // Start non-capturing group for all possible access patterns
+    r'(?:[a-zA-Z0-9_]+\.)+' // e.g., `_appLocalizations.` or `cubit.appLocalizations.`
+    r'|'
+    r'[a-zA-Z0-9_]+\.of\(\s*(?:context|AppNavigation\.context|this\.context|BuildContext\s+\w+)\s*\)\!?\s*\.\s*' // `of(context)!.key` with optional whitespace
+    r'|'
+    r'[a-zA-Z0-9_]+\.\w+\(\s*\)\s*\.\s*' // `SomeClass.method().key`
+    r')'
+    r'(' + keysPattern + r')\b', // The actual key
+    multiLine: true,
+    dotAll: true, // Makes `.` match newlines (crucial for multi-line cases)
+  );
 
-  // Scan Dart files for key usage
   for (final FileSystemEntity file in libDir.listSync(recursive: true)) {
     if (file is File &&
         file.path.endsWith('.dart') &&
         !excludedFiles.contains(file.path)) {
       final String content = file.readAsStringSync();
-      for (final String key in allKeys) {
-        if (RegExp(
-              r'\blocalizations\.' + RegExp.escape(key) + r'\b',
-            ).hasMatch(content) ||
-            RegExp(
-              r'\bS\.of\(context\)\.' + RegExp.escape(key) + r'\b',
-            ).hasMatch(content) ||
-            RegExp(
-              r'\bAppLocalizations\.of\(context\)!.' +
-                  RegExp.escape(key) +
-                  r'\b',
-            ).hasMatch(content)) {
-          usedKeys.add(key);
-        }
+
+      // Quick pre-check: Skip files that don't contain any key substring
+      if (!content.contains(RegExp(keysPattern))) continue;
+
+      for (final Match match in regex.allMatches(content)) {
+        usedKeys.add(match.group(1)!); // Capture only the key
       }
     }
   }


### PR DESCRIPTION
Improve reg speed and read l10n.yaml every code update have comment to be clear why used and added 
Speed was very poor 
890dart file takes more 7m
this pr tested with  developers of my team
everything goes fine with 85% of cases 
tested with more than 25k of dart file 
avg time 30s

✅ Handled Cases
1. Direct Access (Static)
_appLocalizations.key

cubit.appLocalizations.key

SomeClass.someVariable.appLocalizations.key

2. Localizations.of(context) Access
Localizations.of(context)!.key

Localizations.of(context)?.key

Localizations.of(AppNavigation.context)!.key

Localizations.of(this.context)!.key

Localizations.of(BuildContext ctx)!.key