### PR TITLE
Update CHANGELOG and README for version 1.0.3, introducing configurab…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,11 @@
 - 🐛 **Fixed**: Plugin now detects null-aware access (`variable?.key`, `variable?.method(param)`).
 - 🐛 **Fixed**: Plugin now detects method calls with parameters (e.g., `key(type.name)`, `key(e.toString())`).
 - 🐛 **Fixed**: Plugin now detects `AppLocalizations.of(Get.context!,\n)!.key` (formatted multi-line with trailing comma).
+
+## 1.0.3 - Configurable Dart Scan Directories
+
+- ✨ **New**: Add optional `remove_unused_localizations.yaml` config file to specify custom directories to scan for Dart files.
+- 📂 Supports monorepos, shared packages, and projects with Dart code outside `lib`.
+- ⚙️ New `dart-scan-dirs` option: list of directories to scan (paths relative to project root).
+- 🔄 Defaults to `lib` when config is absent for backward compatibility.
+- 📝 Updated README with Configuration section and note about syncing with `l10n.yaml`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ If you want to keep the unused keys in order to delete it manually you can use t
 dart run remove_unused_localizations --keep-unused
 ```
 
+## Configuration
+
+By default, the tool scans only the `lib` directory for Dart files that use localization keys. For monorepos, shared packages, or projects with Dart code in other directories, you can add a `remove_unused_localizations.yaml` config file at your project root (next to `l10n.yaml`).
+
+**Config file:** `remove_unused_localizations.yaml`
+
+```yaml
+# Directories to scan for Dart files that use localization keys.
+# Paths are relative to the project root. Default: [lib]
+dart-scan-dirs:
+  - lib
+  - packages/app1/lib
+  - packages/shared/lib
+```
+
+- The config file is **optional**. When absent, the tool scans `lib` only (backward compatible).
+- Paths in `dart-scan-dirs` are relative to the project root.
+- If a directory does not exist, the tool prints a warning and skips it.
+
+**Note:** If you use a non-standard project structure (e.g. you set `arb-dir` to a custom path like `reference/l10n` in `l10n.yaml`), make sure to also configure `dart-scan-dirs` in `remove_unused_localizations.yaml` to include all directories that contain Dart code using localization keys. Otherwise, the tool may incorrectly mark keys as unused.
+
+**Example for monorepos:**
+
+```yaml
+dart-scan-dirs:
+  - packages/app1/lib
+  - packages/app2/lib
+  - packages/shared/lib
+```
+
 ## Example Output
 
 ```

--- a/lib/src/cleaner.dart
+++ b/lib/src/cleaner.dart
@@ -38,6 +38,45 @@ Set<String> findUsedKeysInContent(String content, Set<String> allKeys) {
   return usedKeys;
 }
 
+/// Reads dart-scan-dirs from remove_unused_localizations.yaml.
+/// Returns ['lib'] if the file is missing, invalid, or the key is absent.
+List<String> _getDartScanDirs() {
+  const String defaultDir = 'lib';
+  const List<String> defaultDirs = [defaultDir];
+
+  final File configFile = File('remove_unused_localizations.yaml');
+  if (!configFile.existsSync()) {
+    return defaultDirs;
+  }
+
+  try {
+    final String content = configFile.readAsStringSync();
+    final dynamic data = loadYaml(content);
+    if (data == null || data is! Map) {
+      return defaultDirs;
+    }
+
+    final dynamic dartScanDirs = data['dart-scan-dirs'];
+    if (dartScanDirs == null) {
+      return defaultDirs;
+    }
+
+    if (dartScanDirs is! YamlList) {
+      return defaultDirs;
+    }
+
+    final List<String> result = dartScanDirs
+        .whereType<String>()
+        .where((s) => s.trim().isNotEmpty)
+        .map((s) => s.trim())
+        .toList();
+
+    return result.isEmpty ? defaultDirs : result;
+  } catch (_) {
+    return defaultDirs;
+  }
+}
+
 /// Scans the project for unused localization keys and removes them from `.arb` files.
 void runLocalizationCleaner({bool keepUnused = false}) {
   final File yamlFile = File('l10n.yaml'); // Path to the l10n.yaml file
@@ -84,15 +123,22 @@ void runLocalizationCleaner({bool keepUnused = false}) {
   }
 
   final Set<String> usedKeys = <String>{};
-  final Directory libDir = Directory('lib');
+  final List<String> dartScanDirs = _getDartScanDirs();
 
   // Scan Dart files for key usage
-  for (final FileSystemEntity file in libDir.listSync(recursive: true)) {
-    if (file is File &&
-        file.path.endsWith('.dart') &&
-        !excludedFiles.contains(file.path)) {
-      final String content = file.readAsStringSync();
-      usedKeys.addAll(findUsedKeysInContent(content, allKeys));
+  for (final String dirPath in dartScanDirs) {
+    final Directory dir = Directory(dirPath);
+    if (!dir.existsSync()) {
+      print('⚠️ Warning: dart-scan-dir "$dirPath" does not exist, skipping.');
+      continue;
+    }
+    for (final FileSystemEntity file in dir.listSync(recursive: true)) {
+      if (file is File &&
+          file.path.endsWith('.dart') &&
+          !excludedFiles.contains(file.path)) {
+        final String content = file.readAsStringSync();
+        usedKeys.addAll(findUsedKeysInContent(content, allKeys));
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: remove_unused_localizations
 description: "A Flutter package to clean unused localization keys from .arb files."
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/OsamaAssaf/remove_unused_localizations
 repository: https://github.com/OsamaAssaf/remove_unused_localizations
 issue_tracker: https://github.com/OsamaAssaf/remove_unused_localizations/issues


### PR DESCRIPTION
…le Dart scan directories via `remove_unused_localizations.yaml`. Enhance `cleaner.dart` to read custom directories for scanning, maintaining backward compatibility with default `lib` directory. Bump version to 1.0.3 in pubspec.yaml.