### PR TITLE
Update CHANGELOG for version 1.1.0, introducing an optional `remove_u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - 🐛 **Fixed**: Plugin now detects method calls with parameters (e.g., `key(type.name)`, `key(e.toString())`).
 - 🐛 **Fixed**: Plugin now detects `AppLocalizations.of(Get.context!,\n)!.key` (formatted multi-line with trailing comma).
 
-## 1.0.3 - Configurable Dart Scan Directories
+## 1.1.0 - Configurable Dart Scan Directories
 
 - ✨ **New**: Add optional `remove_unused_localizations.yaml` config file to specify custom directories to scan for Dart files.
 - 📂 Supports monorepos, shared packages, and projects with Dart code outside `lib`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: remove_unused_localizations
 description: "A Flutter package to clean unused localization keys from .arb files."
-version: 1.0.3
+version: 1.1.0
 homepage: https://github.com/OsamaAssaf/remove_unused_localizations
 repository: https://github.com/OsamaAssaf/remove_unused_localizations
 issue_tracker: https://github.com/OsamaAssaf/remove_unused_localizations/issues


### PR DESCRIPTION
…nused_localizations.yaml` config file for custom Dart scan directories. Bump version to 1.1.0 in pubspec.yaml.