### PR TITLE
chore: Convert to pure Dart package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 linter:
   rules:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: remove_unused_localizations
-description: "A Flutter package to clean unused localization keys from .arb files."
+description: "A Dart package to clean unused localization keys from .arb files."
 version: 1.1.0
 homepage: https://github.com/OsamaAssaf/remove_unused_localizations
 repository: https://github.com/OsamaAssaf/remove_unused_localizations
@@ -7,16 +7,12 @@ issue_tracker: https://github.com/OsamaAssaf/remove_unused_localizations/issues
 
 environment:
   sdk: ^3.7.0
-  flutter: ">=1.17.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   yaml: ^3.1.3
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^5.0.0
+  test: ^1.30.0
+  lints: ^5.0.0
 
 flutter:

--- a/test/remove_unused_localizations_test.dart
+++ b/test/remove_unused_localizations_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:remove_unused_localizations/src/cleaner.dart';
+import 'package:test/test.dart';
 
 void main() {
   const Set<String> testKeys = {


### PR DESCRIPTION
Currently this package is a Flutter package, however as it does not have any Flutter dependencies, it can be convert to a pure Dart package. This allows the package to be used in cli or via pub global.