### PR TITLE
fix: multiline expressions not ending with .

### DIFF
--- a/lib/src/cleaner.dart
+++ b/lib/src/cleaner.dart
@@ -17,11 +17,11 @@ Set<String> findUsedKeysInContent(String content, Set<String> allKeys) {
   final RegExp regex = RegExp(
     // ignore: prefer_interpolation_to_compose_strings
     r'(?:' // Start non-capturing group for all possible access patterns
-        r'(?:[a-zA-Z0-9_]+(?:\?)?\.)+' // e.g., `_appLocalizations.`, `l10n?.` (null-aware)
+        r'(?:[a-zA-Z0-9_]+(?:\?)?\s*\.\s*)+' // e.g., `_appLocalizations.`, `l10n?.` (null-aware)
         r'|'
         r'[a-zA-Z0-9_]+\.of\(\s*(?:context|Get\.context\!?|AppNavigation\.context|this\.context|BuildContext\s+\w+)[\s,]*\)\!?\s*\.\s*' // `of(context)!.key`, `of(Get.context!,\n)!.key`
         r'|'
-        r'[a-zA-Z0-9_]+\.\w+\(\s*\)\s*\.\s*' // `SomeClass.method().key`
+        r'[A-Za-z_]\w*\.[A-Za-z_]\w*\(\s*\)\s*\.\s*' // `SomeClass.method().key`
         r')'
         r'\s*' // Allow whitespace/newlines between accessor and key (fixes multi-line usage)
         r'(' +

--- a/test/remove_unused_localizations_test.dart
+++ b/test/remove_unused_localizations_test.dart
@@ -51,6 +51,18 @@ void main() {
       expect(used, contains('maturity_block_title'));
     });
 
+    test('detects multi-line chained property access', () {
+      const content = '''
+        Text(
+          context
+              .l10n
+              .maturity_block_title,
+        ),
+      ''';
+      final used = findUsedKeysInContent(content, testKeys);
+      expect(used, contains('maturity_block_title'));
+    });
+
     test('detects multi-line method call with parameter', () {
       const content = '''
         final desc = l10n.


### PR DESCRIPTION
When a multiline expression starts with .

```dart
Text(
    context
       .l10n
       .maturity_block_title,
),
```

the regex will incorrectly identify the key as not being used.

This is fixed by not forcing `.` at the end of the line and updating the regex.